### PR TITLE
pin protobuf version in requirements_short.txt

### DIFF
--- a/requirements_short.txt
+++ b/requirements_short.txt
@@ -1,3 +1,4 @@
+protobuf==3.20.*
 torchcrepe
 praat-parselmouth==0.4.1
 scikit-image


### PR DESCRIPTION
protobuf is resolved to 4.x.x without version specified in requirements. This leads to:
```
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
```
Pinning to 3.20.x resolves this issue.
Reference: https://stackoverflow.com/questions/72441758/typeerror-descriptors-cannot-not-be-created-directly